### PR TITLE
Melhorar legibilidade da lib FileHandler

### DIFF
--- a/src/lib/file_handler.py
+++ b/src/lib/file_handler.py
@@ -9,8 +9,8 @@ class FileHandler:
     '''
         Class to handling files.
     '''
-    def extract_lines(self, file: TextIOWrapper) -> List[str]:
+    def get_file_lines_content(self, file: TextIOWrapper) -> List[str]:
         '''
-            Extract file lines.
+            Return the file lines content.
         '''
         return file.readlines()

--- a/tests/lib/test_file_handler.py
+++ b/tests/lib/test_file_handler.py
@@ -13,16 +13,16 @@ class TestFileHandler(TestCase):
     def setUp(self):
         self.file_handler = FileHandler()
 
-    def test_extract_lines(self):
+    def test_get_file_lines_content(self):
         '''
-            Test the method that extract file lines
+            Should return the file lines content.
         '''
         file_mock = MagicMock()
         file_mock.readlines = MagicMock()
         file_mock.readlines.return_value = ['line 1', 'line 2', 'line 3']
 
         # pylint: disable=no-member
-        result = self.file_handler.extract_lines(file_mock)
+        result = self.file_handler.get_file_lines_content(file_mock)
 
         file_mock.readlines.assert_called_once()
         self.assertEqual(result, ['line 1', 'line 2', 'line 3'])


### PR DESCRIPTION
**Contexto:** a lib não estava com o nome do método de leitura do conteúdo do arquivo bem implementado. Se fez necessária a alteração para que se tornasse mais fácil de ler e entender.

**Desenvolvimento:** o método _extract_lines_ teve seu nome alterado para _get_file_lines_content_.