### PR TITLE
Feature/13 adicionar upload de vendas

### DIFF
--- a/src/eureciclo_challenge/settings.py
+++ b/src/eureciclo_challenge/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 
 import environ
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -127,6 +128,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'src/eureciclo_challenge/static')
+]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/src/eureciclo_challenge/static/js/index.js
+++ b/src/eureciclo_challenge/static/js/index.js
@@ -1,0 +1,9 @@
+function changeFilenameSpan(event) {
+  const filenameSpan = document.getElementsByClassName('file-name')[0];
+  
+  filenameSpan.textContent = event.target.files[0].name;
+}
+
+const inputFile = document.getElementsByClassName('file-input')[0];
+
+inputFile.addEventListener('change', changeFilenameSpan, false);

--- a/src/lib/file_handler.py
+++ b/src/lib/file_handler.py
@@ -1,7 +1,7 @@
 '''
     Lib: FileHandler
 '''
-from typing import List
+from typing import List, Union
 from io import TextIOWrapper
 
 
@@ -9,8 +9,23 @@ class FileHandler:
     '''
         Class to handling files.
     '''
+    @classmethod
+    def check_has_bytes_content(
+        cls,
+        content: Union[List[str], List[bytes]]
+    ) -> bool:
+        '''
+            Check if the file was readed as bytes.
+        '''
+        return all(isinstance(data, bytes) for data in content)
+
     def get_file_lines_content(self, file: TextIOWrapper) -> List[str]:
         '''
             Return the file lines content.
         '''
-        return file.readlines()
+        content = file.readlines()
+
+        if self.check_has_bytes_content(content):
+            content = list(map(lambda data: data.decode(), content))
+
+        return content

--- a/src/lib/txt_parser.py
+++ b/src/lib/txt_parser.py
@@ -1,14 +1,15 @@
+# pylint: disable=import-error
 '''
     Lib: TxtParser
 '''
 from typing import List
-from src.errors.lib.txt_parser.invalid_line_content_exception import (
+from errors.lib.txt_parser.invalid_line_content_exception import (
     InvalidLineContentException
 )
-from src.errors.lib.txt_parser.invalid_file_content_exception import (
+from errors.lib.txt_parser.invalid_file_content_exception import (
     InvalidFileContentException
 )
-from src.errors.lib.txt_parser.parse_exception import ParseException
+from errors.lib.txt_parser.parse_exception import ParseException
 
 
 class TxtParser:

--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -4,6 +4,9 @@
 '''
 from typing import Any
 from django.db import models
+from django.core.files.uploadedfile import UploadedFile
+from lib.file_handler import FileHandler
+from lib.txt_parser import TxtParser
 
 
 class Sale(models.Model):
@@ -58,3 +61,16 @@ class Sale(models.Model):
             Return the sales total price.
         '''
         return Sale.objects.aggregate(models.Sum('price'))['price__sum']
+
+    @staticmethod
+    def compose_from_file(
+        file: UploadedFile,
+        file_handler: FileHandler,
+        txt_parser: TxtParser
+    ) -> dict:
+        '''
+            Compose the sales data from the uploaded file.
+        '''
+        file_content = file_handler.get_file_lines_content(file)
+
+        return txt_parser.get_composed_sales(file_content)

--- a/src/sales/templates/index.html
+++ b/src/sales/templates/index.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load static %}
 {% block metainfo %}
   <title>Home</title>
 {% endblock %}
@@ -10,7 +9,7 @@
       <form class="is-flex is-flex-direction-column is-align-items-center">
         <div class="file is-centered is-boxed">
           <label class="file-label">
-            <input class="file-input" type="file" name="sales-import">
+            <input class="file-input" type="file" name="sales-import" accept=".txt">
             <span class="file-cta">
               <span class="file-label">
                 Escolha o arquivo ...
@@ -49,4 +48,6 @@
       </div>
     </div>
   </div>
+  {% load static %}
+  <script src="{% static 'js/index.js' %}" defer></script>
 {% endblock %}

--- a/src/sales/templates/index.html
+++ b/src/sales/templates/index.html
@@ -6,10 +6,11 @@
   <div class="container pb-6 my-6">
     <div class="is-flex is-flex-direction-column is-align-items-center">
       <h1 class="title">Adicione mais vendas</h1>
-      <form class="is-flex is-flex-direction-column is-align-items-center">
+      <form action="{% url 'sales:processing' %}" method="POST" enctype="multipart/form-data" class="is-flex is-flex-direction-column is-align-items-center">
+        {% csrf_token %}
         <div class="file is-centered is-boxed">
           <label class="file-label">
-            <input class="file-input" type="file" name="sales-import" accept=".txt">
+            <input class="file-input" type="file" name="sales" accept=".txt" required>
             <span class="file-cta">
               <span class="file-label">
                 Escolha o arquivo ...

--- a/src/sales/templates/processing.html
+++ b/src/sales/templates/processing.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block metainfo %}
+  <title>Processamento</title>
+{% endblock %}
+{% block content %}
+  <p>{{ file }}</p>
+{% endblock %}

--- a/src/sales/urls.py
+++ b/src/sales/urls.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member
+# pylint: disable=no-member,import-error
 '''
   Sales urls.
 '''
@@ -10,4 +10,5 @@ app_name = "sales"  # pylint: disable=invalid-name
 
 urlpatterns = [
     path("", views.HomeView.as_view(), name="home"),
+    path("processing/", views.ProcessingView.as_view(), name="processing")
 ]

--- a/src/sales/views.py
+++ b/src/sales/views.py
@@ -5,6 +5,9 @@
 from django.views.generic import TemplateView
 from django.shortcuts import render
 from django.http import HttpResponse
+
+from lib.file_handler import FileHandler
+from lib.txt_parser import TxtParser
 from .models import Sale
 
 
@@ -26,3 +29,25 @@ class HomeView(TemplateView):
         }
 
         return render(self.request, 'index.html', data)
+
+
+class ProcessingView(TemplateView):
+    '''
+        Processing sale view.
+    '''
+    template_name = 'processing.html'
+
+    def post(self, *args, **kwargs) -> HttpResponse:
+        '''
+            Process the import sales file.
+        '''
+        file_handler = FileHandler()
+        txt_parser = TxtParser()
+
+        sales_info = Sale.compose_from_file(
+            self.request.FILES['sales'],
+            file_handler,
+            txt_parser
+        )
+
+        return render(self.request, 'processing.html', {'sales': sales_info})

--- a/tests/lib/test_file_handler.py
+++ b/tests/lib/test_file_handler.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-member
 '''
     FileHandler tests
 '''
@@ -13,6 +14,28 @@ class TestFileHandler(TestCase):
     def setUp(self):
         self.file_handler = FileHandler()
 
+    def test_check_has_bytes_content_with_bytes_list(self):
+        '''
+            Should return true when the content list elements
+            are bytes.
+        '''
+        content_mock = [b'content 1', b'content 2']
+
+        result = self.file_handler.check_has_bytes_content(content_mock)
+
+        self.assertTrue(result)
+
+    def test_check_has_bytes_content_with_str_list(self):
+        '''
+            Should return false when the content list elements
+            are strings.
+        '''
+        content_mock = ['content 1', 'content 2']
+
+        result = self.file_handler.check_has_bytes_content(content_mock)
+
+        self.assertFalse(result)
+
     def test_get_file_lines_content(self):
         '''
             Should return the file lines content.
@@ -20,6 +43,20 @@ class TestFileHandler(TestCase):
         file_mock = MagicMock()
         file_mock.readlines = MagicMock()
         file_mock.readlines.return_value = ['line 1', 'line 2', 'line 3']
+
+        # pylint: disable=no-member
+        result = self.file_handler.get_file_lines_content(file_mock)
+
+        file_mock.readlines.assert_called_once()
+        self.assertEqual(result, ['line 1', 'line 2', 'line 3'])
+
+    def test_get_file_lines_content_with_file_content_as_bytes(self):
+        '''
+            Should return the file lines content converted to str.
+        '''
+        file_mock = MagicMock()
+        file_mock.readlines = MagicMock()
+        file_mock.readlines.return_value = [b'line 1', b'line 2', b'line 3']
 
         # pylint: disable=no-member
         result = self.file_handler.get_file_lines_content(file_mock)

--- a/tests/lib/test_txt_parser.py
+++ b/tests/lib/test_txt_parser.py
@@ -1,13 +1,13 @@
-# pylint: disable=no-member
+# pylint: disable=no-member,import-error
 '''
     TxtParser tests
 '''
 from unittest import TestCase, main
-from src.lib.txt_parser import TxtParser
-from src.errors.lib.txt_parser.invalid_line_content_exception import (
+from lib.txt_parser import TxtParser
+from errors.lib.txt_parser.invalid_line_content_exception import (
     InvalidLineContentException
 )
-from src.errors.lib.txt_parser.invalid_file_content_exception import (
+from errors.lib.txt_parser.invalid_file_content_exception import (
     InvalidFileContentException
 )
 
@@ -44,7 +44,6 @@ class TestTxtParser(TestCase):
         line_mock = None
 
         with self.assertRaises(InvalidLineContentException):
-
             self.txt_parser.get_sale_content_from_line(line_mock)
 
     def test_compose_sale(self):

--- a/tests/sales/models/test_sale.py
+++ b/tests/sales/models/test_sale.py
@@ -2,6 +2,7 @@
 '''
     Sale model tests.
 '''
+from unittest.mock import MagicMock
 from django.test import TestCase
 from sales.models import Sale
 
@@ -101,3 +102,25 @@ class TestSale(TestCase):
         result = Sale.get_total_price()
 
         self.assertEqual(result, 40.0)
+
+    def test_compose_from_file(self):
+        '''
+            Should return the composed sales.
+        '''
+        file_handler_mock = MagicMock()
+        file_handler_mock.get_file_lines_content = MagicMock()
+        file_handler_mock.get_file_lines_content.return_value = 'lines content'
+
+        txt_parser_mock = MagicMock()
+        txt_parser_mock.get_composed_sales = MagicMock()
+        txt_parser_mock.get_composed_sales.return_value = 'composed sales'
+
+        result = Sale.compose_from_file(
+            'file',
+            file_handler_mock,
+            txt_parser_mock
+        )
+
+        file_handler_mock.get_file_lines_content.assert_called_once_with('file')  # noqa: E501
+        txt_parser_mock.get_composed_sales.assert_called_once_with('lines content')  # noqa: E501
+        self.assertEqual(result, 'composed sales')

--- a/tests/sales/views/__mocks__/sales.txt
+++ b/tests/sales/views/__mocks__/sales.txt
@@ -1,0 +1,5 @@
+Comprador	Descrição	Preço Unitário	Quantidade	Endereço	Fornecedor
+João Silva	R$10 off R$20 of food	10.0	2	987 Fake St	Bob's Pizza
+Amy Pond	R$30 of awesome for R$10	10.0	5	456 Unreal Rd	Tom's Awesome Shop
+Marty McFly	R$20 Sneakers for R$5	5.0	1	123 Fake St	Sneaker Store Emporium
+Snake Plissken	R$20 Sneakers for R$5	5.0	4	123 Fake St	Sneaker Store Emporium

--- a/tests/sales/views/test_processing_view.py
+++ b/tests/sales/views/test_processing_view.py
@@ -1,0 +1,29 @@
+# pylint: disable=no-member,import-error
+'''
+    Home view tests.
+'''
+from pathlib import Path
+from django.test import TestCase, Client
+
+
+class TestProcessingView(TestCase):
+    '''
+            Home view test cases.
+    '''
+    def setUp(self):
+        self.client = Client()
+        self.sales_mock_file_path = f'{Path(__file__).parent}/__mocks__/sales.txt'  # noqa: E501
+
+    def test_file_upload(self):
+        '''
+            Should render the sales data.
+        '''
+
+        with open(self.sales_mock_file_path, 'rb') as uploaded_file:
+            response = self.client.post(
+                '/sales/processing/',
+                {'sales': uploaded_file}
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertIsNotNone(response.context['sales'])


### PR DESCRIPTION
**Contexto:** adicionar funcionalidade do upload de arquivos com as vendas. Até o momento as vendas são importadas e renderizadas sem estilo na página de processamento.

**Desenvolvimento:** foram adicionadas as funcionalidades pedidas na descrição da issue e a página de processamento mostrando apenas os dados importados do arquivo. Próximos passos serão estilizar a renderização dos dados e adicionar botão de confirmação de salvamento.