### PR TITLE
Implementar save dos dados importados

### DIFF
--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -2,7 +2,7 @@
 '''
     Sale app models.
 '''
-from typing import Any
+from typing import Any, List
 from django.db import models
 from django.core.files.uploadedfile import UploadedFile
 from lib.file_handler import FileHandler
@@ -74,3 +74,11 @@ class Sale(models.Model):
         file_content = file_handler.get_file_lines_content(file)
 
         return txt_parser.get_composed_sales(file_content)
+
+    @staticmethod
+    def create_from_list(sales_list: List[dict]) -> None:
+        '''
+            Create sales from a list.
+        '''
+        for sale in sales_list:
+            Sale.create(sale)

--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -98,6 +98,6 @@ class Sale(models.Model):
         total_price = 0.0
 
         for sale in sales:
-            total_price += sale['price'] * sale['quantity']
+            total_price += float(sale['price']) * int(sale['quantity'])
 
         return total_price

--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -89,3 +89,15 @@ class Sale(models.Model):
             Return the number of imported sales from a file.
         '''
         return len(sales)
+
+    @staticmethod
+    def get_total_price_from_imported_sales(sales: list) -> float:
+        '''
+            Return the imported sales total price.
+        '''
+        total_price = 0.0
+
+        for sale in sales:
+            total_price += sale['price'] * sale['quantity']
+
+        return total_price

--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -82,3 +82,10 @@ class Sale(models.Model):
         '''
         for sale in sales_list:
             Sale.create(sale)
+
+    @staticmethod
+    def get_total_imported_sales(sales: list) -> int:
+        '''
+            Return the number of imported sales from a file.
+        '''
+        return len(sales)

--- a/src/sales/templates/processing.html
+++ b/src/sales/templates/processing.html
@@ -3,5 +3,41 @@
   <title>Processamento</title>
 {% endblock %}
 {% block content %}
-  <p>{{ file }}</p>
+  <div class="container pb-6 my-6">
+    <div class="pb-4">
+      <h1 class="title">Vendas a importar</h1>
+    </div>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Comprador</th>
+          <th>Descrição</th>
+          <th>Preço</th>
+          <th>Quantidade</th>
+          <th>Endereço</th>
+          <th>Fornecedor</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for sale in sales %}
+          <tr>
+            <td>{{ sale.buyer }}</td>
+            <td>{{ sale.description }}</td>
+            <td>{{ sale.price }}</td>
+            <td>{{ sale.quantity }}</td>
+            <td>{{ sale.address }}</td>
+            <td>{{ sale.provider }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="columns py-4">
+      <div class="column is-1">
+        <a class="button is-light" href="{% url 'sales:home' %}">Cancelar</a>
+      </div>
+      <div class="column is-1 ml-4">
+        <a class="button is-success">Salvar</a>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/src/sales/templates/processing.html
+++ b/src/sales/templates/processing.html
@@ -36,7 +36,7 @@
         <a class="button is-light" href="{% url 'sales:home' %}">Cancelar</a>
       </div>
       <div class="column is-1 ml-4">
-        <a class="button is-success">Salvar</a>
+        <a class="button is-success" href="{% url 'sales:result' %}">Salvar</a>
       </div>
     </div>
   </div>

--- a/src/sales/templates/result.html
+++ b/src/sales/templates/result.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block metainfo %}
+  <title>Resultado</title>
+{% endblock %}
+{% block content %}
+  <div class="container pb-6 my-6">
+    <div class="pb-4">
+      <h1 class="title">Dados importados</h1>
+    </div>
+    <div class="is-flex is-justify-content-center py-4">
+      <a class="button is-light" href="{% url 'sales:home' %}">Fechar</a>
+    </div>
+  </div>
+{% endblock %}

--- a/src/sales/templates/result.html
+++ b/src/sales/templates/result.html
@@ -7,6 +7,20 @@
     <div class="pb-4">
       <h1 class="title">Dados importados</h1>
     </div>
+    <div class="level">
+      <div class="level-item has-text-centered">
+        <div>
+          <p class="heading">Vendas importadas</p>
+          <p class="title">{{ total_imported_sales }}</p>
+        </div>
+      </div>
+      <div class="level-item has-text-centered">
+        <div>
+          <p class="heading">Receita bruta total</p>
+          <p class="title">R$ {{ total_price|floatformat:2 }}</p>
+        </div>
+      </div>
+    </div>
     <div class="is-flex is-justify-content-center py-4">
       <a class="button is-light" href="{% url 'sales:home' %}">Fechar</a>
     </div>

--- a/src/sales/urls.py
+++ b/src/sales/urls.py
@@ -10,5 +10,6 @@ app_name = "sales"  # pylint: disable=invalid-name
 
 urlpatterns = [
     path("", views.HomeView.as_view(), name="home"),
-    path("processing/", views.ProcessingView.as_view(), name="processing")
+    path("processing/", views.ProcessingView.as_view(), name="processing"),
+    path("processing/result", views.ResultView.as_view(), name="result")
 ]

--- a/src/sales/views.py
+++ b/src/sales/views.py
@@ -53,3 +53,13 @@ class ProcessingView(TemplateView):
         self.request.session['sales_info'] = sales_info
 
         return render(self.request, 'processing.html', {'sales': sales_info})
+
+
+class ResultView(TemplateView):
+    '''
+        Import result view.
+    '''
+    template_name = 'result.html'
+
+    def post(self, *args, **kwargs) -> HttpResponse:
+        return render(self.request, 'result.html')

--- a/src/sales/views.py
+++ b/src/sales/views.py
@@ -3,7 +3,7 @@
     Sales views.
 '''
 from django.views.generic import TemplateView
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 
 from lib.file_handler import FileHandler
@@ -61,5 +61,28 @@ class ResultView(TemplateView):
     '''
     template_name = 'result.html'
 
-    def post(self, *args, **kwargs) -> HttpResponse:
-        return render(self.request, 'result.html')
+    def get(self, *args, **kwargs) -> HttpResponse:
+        '''
+            Save the sales and render the results.
+        '''
+        self.request.session.modified = True
+        sales_info = self.request.session.get('sales_info')
+
+        if not sales_info:
+            return redirect('/sales')
+
+        Sale.create_from_list(sales_info)
+
+        total_imported_sales = Sale.get_total_imported_sales(sales_info)
+        total_price_from_imported_sales = Sale.get_total_price_from_imported_sales(  # noqa: E501
+            sales_info
+        )
+
+        results = {
+            'total_imported_sales': total_imported_sales,
+            'total_price': total_price_from_imported_sales
+        }
+
+        self.request.session['sales_info'] = None
+
+        return render(self.request, 'result.html', results)

--- a/src/sales/views.py
+++ b/src/sales/views.py
@@ -50,4 +50,6 @@ class ProcessingView(TemplateView):
             txt_parser
         )
 
+        self.request.session['sales_info'] = sales_info
+
         return render(self.request, 'processing.html', {'sales': sales_info})

--- a/tests/sales/models/test_sale.py
+++ b/tests/sales/models/test_sale.py
@@ -37,6 +37,33 @@ class TestSale(TestCase):
         sale_created = Sale.objects.last()
 
         self.assertEqual(sale_created.buyer, 'João Silva')
+    
+    def test_create_from_list(self):
+        '''
+            Should create sales from a list.
+        '''
+        list_mock = [
+            {
+                'buyer': "Test 1",
+                'description': "description",
+                'price': 10.0,
+                'quantity': 2,
+                'address': "address",
+                'provider': "provider"
+            },
+            {
+                'buyer': "Test 2",
+                'description': "description",
+                'price': 10.0,
+                'quantity': 2,
+                'address': "address",
+                'provider': "provider"
+            }
+        ]
+
+        Sale.create_from_list(list_mock)
+
+        self.assertEqual(Sale.objects.count(), 2)
 
     def test_last_sale(self):
         '''

--- a/tests/sales/models/test_sale.py
+++ b/tests/sales/models/test_sale.py
@@ -162,3 +162,23 @@ class TestSale(TestCase):
         result = Sale.get_total_imported_sales(sales_mock)
 
         self.assertEqual(result, 3)
+
+    def test_get_total_price_from_imported_sales(self):
+        '''
+            Should return the imported sales total
+            price.
+        '''
+        sales_mock = [
+            {
+                'price': 10.0,
+                'quantity': 2
+            },
+            {
+                'price': 5.0,
+                'quantity': 3
+            }
+        ]
+
+        result = Sale.get_total_price_from_imported_sales(sales_mock)
+
+        self.assertEqual(result, 35.0)

--- a/tests/sales/models/test_sale.py
+++ b/tests/sales/models/test_sale.py
@@ -37,7 +37,7 @@ class TestSale(TestCase):
         sale_created = Sale.objects.last()
 
         self.assertEqual(sale_created.buyer, 'João Silva')
-    
+
     def test_create_from_list(self):
         '''
             Should create sales from a list.
@@ -151,3 +151,14 @@ class TestSale(TestCase):
         file_handler_mock.get_file_lines_content.assert_called_once_with('file')  # noqa: E501
         txt_parser_mock.get_composed_sales.assert_called_once_with('lines content')  # noqa: E501
         self.assertEqual(result, 'composed sales')
+
+    def test_get_total_imported_sales(self):
+        '''
+            Should return the total imported sales
+            from file number.
+        '''
+        sales_mock = ['sale 1', 'sale 2', 'sale 3']
+
+        result = Sale.get_total_imported_sales(sales_mock)
+
+        self.assertEqual(result, 3)

--- a/tests/sales/views/test_processing_view.py
+++ b/tests/sales/views/test_processing_view.py
@@ -27,3 +27,4 @@ class TestProcessingView(TestCase):
 
             self.assertEqual(response.status_code, 200)
             self.assertIsNotNone(response.context['sales'])
+            self.assertIsNotNone(self.client.session.get('sales_info'))

--- a/tests/sales/views/test_result_view.py
+++ b/tests/sales/views/test_result_view.py
@@ -1,0 +1,21 @@
+# pylint: disable=no-member,import-error
+'''
+    Result view tests.
+'''
+from django.test import TestCase, Client
+
+
+class TestProcessingView(TestCase):
+    '''
+            Result view test cases.
+    '''
+    def setUp(self):
+        self.client = Client()
+
+    def test_result(self):
+        '''
+            Should render the import results.
+        '''
+        response = self.client.get('/sales/processing/result')
+
+        self.assertEqual(response.status_code, 200)

--- a/tests/sales/views/test_result_view.py
+++ b/tests/sales/views/test_result_view.py
@@ -12,10 +12,33 @@ class TestProcessingView(TestCase):
     def setUp(self):
         self.client = Client()
 
-    def test_result(self):
+    def test_result_without_sales_info_session(self):
         '''
-            Should render the import results.
+            Should to redirect to the homepage
+            when the sales informations are not
+            in the session request.
         '''
         response = self.client.get('/sales/processing/result')
 
+        self.assertRedirects(response, '/sales', target_status_code=301)
+
+    def test_results(self):
+        '''
+            Should render the import sales result.
+        '''
+        session = self.client.session
+        session['sales_info'] = [{
+            'buyer': "View Test",
+            'description': "description",
+            'price': 10.0,
+            'quantity': 2,
+            'address': "address",
+            'provider': "provider"
+        }]
+        session.save()
+
+        response = self.client.get('/sales/processing/result')
+
         self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context['total_imported_sales'])
+        self.assertIsNotNone(response.context['total_price'])


### PR DESCRIPTION
**Contexto:** a página de save dos dados estava criada mas sem as funcionalidades implementadas. A página devia salvar os dados no banco de dados e após mostrar um resumo da importação do arquivo.

**Desenvolvimento:** foram adicionadas as alterações necessárias para o save dos dados e o resumo das informações posteriormente. Os dados da importação são passadas da página de processamento para a página de resultado através da session da request. Foi adicionada uma verificação quando a página de resultado é mostrada: caso os dados das vendas não estejam salvos na session da request, a página é redirecionada para a de importação.