### PR TITLE
Adicionar redirecionamento do path raiz para a página de importação

### DIFF
--- a/src/eureciclo_challenge/urls.py
+++ b/src/eureciclo_challenge/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('sales/', include('sales.urls', namespace='sales'))
+    path('sales/', include('sales.urls', namespace='sales')),
+    path('', RedirectView.as_view(url='/sales', permanent=True))
 ]


### PR DESCRIPTION
**Contexto:** quando se acessava o path raiz (_/_) acontecia um erro. Para contornar isso, o redirecionamento para a principal página da aplicação se fez necessário.

**Desenvolvimento:** o path raiz foi adicionado às urls da aplicação com uma _RedirectView_ apontando para a página _/sales_.