### PR TITLE
Corrigir possível erro de tipo no método de criação de venda

### DIFF
--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -31,8 +31,8 @@ class Sale(models.Model):
         try:
             buyer = sale_data['buyer']
             description = sale_data['description']
-            price = sale_data['price']
-            quantity = sale_data['quantity']
+            price = float(sale_data['price'])
+            quantity = int(sale_data['quantity'])
             address = sale_data['address']
             provider = sale_data['provider']
         except KeyError:

--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -5,6 +5,9 @@
 from typing import Any, List
 from django.db import models
 from django.core.files.uploadedfile import UploadedFile
+from errors.lib.txt_parser.invalid_file_content_exception import (
+    InvalidFileContentException
+)
 from lib.file_handler import FileHandler
 from lib.txt_parser import TxtParser
 
@@ -25,12 +28,15 @@ class Sale(models.Model):
         '''
             Create a sale.
         '''
-        buyer = sale_data['buyer']
-        description = sale_data['description']
-        price = sale_data['price']
-        quantity = sale_data['quantity']
-        address = sale_data['address']
-        provider = sale_data['provider']
+        try:
+            buyer = sale_data['buyer']
+            description = sale_data['description']
+            price = sale_data['price']
+            quantity = sale_data['quantity']
+            address = sale_data['address']
+            provider = sale_data['provider']
+        except KeyError:
+            raise InvalidFileContentException() from KeyError
 
         cls.objects.create(
             buyer=buyer,

--- a/tests/sales/models/test_sale.py
+++ b/tests/sales/models/test_sale.py
@@ -4,6 +4,9 @@
 '''
 from unittest.mock import MagicMock
 from django.test import TestCase
+from errors.lib.txt_parser.invalid_file_content_exception import (
+    InvalidFileContentException
+)
 from sales.models import Sale
 
 
@@ -37,6 +40,16 @@ class TestSale(TestCase):
         sale_created = Sale.objects.last()
 
         self.assertEqual(sale_created.buyer, 'João Silva')
+
+    def test_create_with_invalid_sale_data(self):
+        '''
+            Should raise an exception when the sale data
+            does not have complete info.
+        '''
+        with self.assertRaises(InvalidFileContentException):
+            Sale.create({
+                'buyer': 'Test'
+            })
 
     def test_create_from_list(self):
         '''


### PR DESCRIPTION
**Contexto:** os valores de preço e quantidade estavam entrando como strings na função de criação. Embora não estivesse acontecendo nenhum erro, era um possível bug.

**Desenvolvimento:** foi adicionado o cast explícito e um tratamento de erro quando não existirem dados em alguma chave do dicionário com os dados da venda.