### PR TITLE
Adicionar verificação na renderização do valor total das vendas

### DIFF
--- a/src/sales/models.py
+++ b/src/sales/models.py
@@ -47,6 +47,13 @@ class Sale(models.Model):
             provider=provider,
         )
 
+    @property
+    def total_price(self) -> float:
+        '''
+            Return sale's total price.
+        '''
+        return self.price * self.quantity
+
     @staticmethod
     def get_last() -> Any:
         '''
@@ -66,7 +73,9 @@ class Sale(models.Model):
         '''
             Return the sales total price.
         '''
-        return Sale.objects.aggregate(models.Sum('price'))['price__sum']
+        all_sales = Sale.objects.all()
+
+        return sum(list(map(lambda sale: sale.total_price, all_sales)))
 
     @staticmethod
     def compose_from_file(

--- a/src/sales/templates/index.html
+++ b/src/sales/templates/index.html
@@ -30,7 +30,7 @@
       <div>
         <p class="heading">Última venda</p>
         {% if last_sale %}
-          <p class="title">{{ last_sale.buyer }} - R$ {{ last_sale.price|floatformat:2 }}</p>
+          <p class="title">{{ last_sale.buyer }} - R$ {{ last_sale.total_price|floatformat:2 }}</p>
         {% else %}
           <p>Sem vendas cadastradas</p>
         {% endif %}

--- a/src/sales/templates/index.html
+++ b/src/sales/templates/index.html
@@ -32,7 +32,7 @@
         {% if last_sale %}
           <p class="title">{{ last_sale.buyer }} - R$ {{ last_sale.price|floatformat:2 }}</p>
         {% else %}
-          <p class="title">Sem vendas cadastradas</p>
+          <p>Sem vendas cadastradas</p>
         {% endif %}
       </div>
     </div>
@@ -45,7 +45,11 @@
     <div class="level-item has-text-centered">
       <div>
         <p class="heading">Valor total das vendas</p>
-        <p class="title">R$ {{ sales_total_price|floatformat:2 }}</p>
+        {% if sales_total_price %}
+          <p class="title">R$ {{ sales_total_price|floatformat:2 }}</p>
+        {% else %}
+          <p class="title">-</p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/tests/sales/models/test_sale.py
+++ b/tests/sales/models/test_sale.py
@@ -141,7 +141,7 @@ class TestSale(TestCase):
 
         result = Sale.get_total_price()
 
-        self.assertEqual(result, 40.0)
+        self.assertEqual(result, 80.0)
 
     def test_compose_from_file(self):
         '''

--- a/tests/sales/views/test_home_view.py
+++ b/tests/sales/views/test_home_view.py
@@ -53,7 +53,7 @@ class TestHomeView(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(response.context['last_sale'])
-        self.assertContains(response, 'View Test - R$ 10.00')
+        self.assertContains(response, 'View Test - R$ 20.00')
 
     def test_sales_count(self):
         '''
@@ -79,5 +79,5 @@ class TestHomeView(TestCase):
         response = self.client.get('/sales/')
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['sales_total_price'], 20.0)
-        self.assertContains(response, 'R$ 20.00')
+        self.assertEqual(response.context['sales_total_price'], 40.0)
+        self.assertContains(response, 'R$ 40.00')


### PR DESCRIPTION
**Contexto:** quando não existia vendas no banco o total de vendas ficava "R$", deixando um layout inconsistente. E o cálculo do valor total de vendas estava errado, pois estava considerando apenas o valor unitário.

**Desenvolvimento:** o problema na renderização e o bug do do valor total foram corrigidos.