### PR TITLE
Correção de bug ao cancelar importação

### DIFF
--- a/src/sales/views.py
+++ b/src/sales/views.py
@@ -30,7 +30,9 @@ class HomeView(TemplateView):
         sales_total_price = Sale.get_total_price()
 
         error = self.request.session.get('import_sales_error')
+
         self.request.session['import_sales_error'] = None
+        self.request.session['sales_info'] = None
 
         data = {
             'last_sale': last_sale,


### PR DESCRIPTION
**Contexto:** quando o usuário fazia o upload do arquivo e na página de processamento cancelava a importação, os dados das vendas ficavam salvos na session. Caso o usuário viesse a acessar a página de resultado diretamente, os dados da importação cancelada eram salvos no banco.

**Desenvolvimento:** foi adicionada a limpeza dos dados de venda na session sempre que a página de importação é acessada.