### PR TITLE
Remover arquivos não utilizados app sales

### DIFF
--- a/src/sales/admin.py
+++ b/src/sales/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/src/sales/apps.py
+++ b/src/sales/apps.py
@@ -1,6 +1,12 @@
+'''
+    Config that is loaded in the settings INSTALLED_APPS.
+'''
 from django.apps import AppConfig
 
 
 class SalesConfig(AppConfig):
+    '''
+        Sales app config.
+    '''
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'sales'

--- a/src/sales/tests.py
+++ b/src/sales/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.


### PR DESCRIPTION
**Contexto:** alguns arquivos do app _sales_não eram utilizados e portanto eram dispensáveis ao projeto.

**Desenvolvimento:** deleção dos arquivos _admin_ e _tests_ e adição de docstring do módulo _apps_.