### PR TITLE
Correção de teste de upload de arquivo inválido

### DIFF
--- a/tests/sales/views/test_processing_view.py
+++ b/tests/sales/views/test_processing_view.py
@@ -70,5 +70,5 @@ class TestProcessingView(TestCase):
             )
             self.assertEqual(
                 self.client.session.get('import_sales_error'),
-                'Dados das vendas inválidos'
+                'Informações da venda incorretas. As informações necessárias são: comprador, descrição, preço unitário, quantidade, endereço e fornecedor'  # noqa: E501
             )


### PR DESCRIPTION
**Contexto:** teste quebrou após alterações nas mensagens de erro.

**Desenvolvimento:** a mensagem que é comparada no teste foi alterada para a correta.