### PR TITLE
Corrigir estilos da página de importação

### DIFF
--- a/src/sales/templates/import.html
+++ b/src/sales/templates/import.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block metainfo %}
-  <title>Home</title>
+  <title>Importar vendas</title>
 {% endblock %}
 {% block content %}
   <div class="container pb-6 my-6">
@@ -35,7 +35,7 @@
       <div>
         <p class="heading">Última venda</p>
         {% if last_sale %}
-          <p class="title">{{ last_sale.buyer }} - R$ {{ last_sale.total_price|floatformat:2 }}</p>
+          <p class="title is-4">{{ last_sale.buyer }} - R$ {{ last_sale.total_price|floatformat:2 }}</p>
         {% else %}
           <p>Sem vendas cadastradas</p>
         {% endif %}


### PR DESCRIPTION
**Contexto:** a página de importação estava com o título da página errado. E o estilo da informação de última venda estava muito grande, deixando o estilo das informações das vendas quebrado.

**Desenvolvimento:** o título da página foi alterado para _Importar vendas_ e o tamanho da informação de última foi diminuído.