### PR TITLE
Aumentar coverage das views

### DIFF
--- a/src/errors/lib/txt_parser/parse_exception.py
+++ b/src/errors/lib/txt_parser/parse_exception.py
@@ -6,10 +6,7 @@
 class ParseException(Exception):
     '''
         Exception that should be raises when an error
-        occurred while the parsing is doing.
+        occurred while the parsing have been doing.
     '''
-    def __init__(self, error_message: str):
-        Exception.__init__(
-            self,
-            f'An error occurred while parsing the file content. Error: {error_message}'  # noqa: E501
-        )
+    def __init__(self, message: str):
+        Exception.__init__(self, message)

--- a/src/lib/txt_parser.py
+++ b/src/lib/txt_parser.py
@@ -57,7 +57,9 @@ class TxtParser:
                 sale_info = sale_keys[index]
                 data_dict[sale_info] = sale_content
         except Exception as error:
-            raise ParseException(error) from error
+            raise ParseException(
+                f'Aconteceu um erro durante o parseamento do arquivo: {error}'
+            ) from error
 
         return data_dict
 

--- a/src/sales/views.py
+++ b/src/sales/views.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member,import-error
+# pylint: disable=no-member,import-error,unused-argument
 '''
     Import views.
 '''
@@ -68,8 +68,8 @@ class ProcessingView(TemplateView):
             error = str(invalid_file_content)
         except InvalidLineContentException as invalid_line_content:
             error = str(invalid_line_content)
-        except ParseException:
-            error = 'Erro ao parsear os dados do arquivo'
+        except ParseException as parse_exception:
+            error = str(parse_exception)
         except Exception as unknown_error:  # pylint: disable=broad-except
             error = f'Aconteceu um erro desconhecido. Descrição: {str(unknown_error)}'  # noqa: E501
 

--- a/src/sales/views.py
+++ b/src/sales/views.py
@@ -71,7 +71,7 @@ class ProcessingView(TemplateView):
         except ParseException as parse_exception:
             error = str(parse_exception)
         except Exception as unknown_error:  # pylint: disable=broad-except
-            error = f'Aconteceu um erro desconhecido. Descrição: {str(unknown_error)}'  # noqa: E501
+            error = f'Aconteceu um erro desconhecido: {str(unknown_error)}'  # noqa: E501
 
         if error:
             self.request.session['import_sales_error'] = error

--- a/tests/sales/views/test_processing_view.py
+++ b/tests/sales/views/test_processing_view.py
@@ -101,7 +101,7 @@ class TestProcessingView(TestCase):
                 )
                 self.assertEqual(
                     self.client.session.get('import_sales_error'),
-                    'test error'   # noqa: E501
+                    'test error'
                 )
 
     def test_file_upload_unknown_error(self):

--- a/tests/sales/views/test_processing_view.py
+++ b/tests/sales/views/test_processing_view.py
@@ -3,7 +3,9 @@
     Home view tests.
 '''
 from pathlib import Path
+from unittest.mock import patch
 from django.test import TestCase, Client
+from errors.lib.txt_parser.parse_exception import ParseException
 
 
 class TestProcessingView(TestCase):
@@ -72,3 +74,32 @@ class TestProcessingView(TestCase):
                 self.client.session.get('import_sales_error'),
                 'Informações da venda incorretas. As informações necessárias são: comprador, descrição, preço unitário, quantidade, endereço e fornecedor'  # noqa: E501
             )
+
+    def test_file_upload_parse_error(self):
+        '''
+            Should redirect to import page when the
+            ParseException raises.
+        '''
+        uploaded_file_path = f'{self.sales_mock_files_path}/sales.txt'
+        with open(uploaded_file_path, 'rb') as uploaded_file:
+            with patch(
+                'sales.models.Sale.compose_from_file'
+            ) as compose_sale_from_file_mock:
+                compose_sale_from_file_mock.side_effect = ParseException(
+                    'test error'
+                )
+
+                response = self.client.post(
+                    '/sales/import/processing/',
+                    {'sales': uploaded_file}
+                )
+
+                self.assertRedirects(
+                    response,
+                    '/sales/import',
+                    target_status_code=301
+                )
+                self.assertEqual(
+                    self.client.session.get('import_sales_error'),
+                    'test error'   # noqa: E501
+                )

--- a/tests/sales/views/test_processing_view.py
+++ b/tests/sales/views/test_processing_view.py
@@ -103,3 +103,32 @@ class TestProcessingView(TestCase):
                     self.client.session.get('import_sales_error'),
                     'test error'   # noqa: E501
                 )
+
+    def test_file_upload_unknown_error(self):
+        '''
+            Should redirect to import page when a unknown
+            Exception raises.
+        '''
+        uploaded_file_path = f'{self.sales_mock_files_path}/sales.txt'
+        with open(uploaded_file_path, 'rb') as uploaded_file:
+            with patch(
+                'sales.models.Sale.compose_from_file'
+            ) as compose_sale_from_file_mock:
+                compose_sale_from_file_mock.side_effect = Exception(
+                    'test error'
+                )
+
+                response = self.client.post(
+                    '/sales/import/processing/',
+                    {'sales': uploaded_file}
+                )
+
+                self.assertRedirects(
+                    response,
+                    '/sales/import',
+                    target_status_code=301
+                )
+                self.assertEqual(
+                    self.client.session.get('import_sales_error'),
+                    'Aconteceu um erro desconhecido: test error'
+                )


### PR DESCRIPTION
**Contexto:** devido a uma das regras de avaliação ser 100% de cobertura de testes em controllers (views no caso do Django) e models, essa tarefa se fez necessária.

**Desenvolvimento:** foram adicionados os testes referentes a tratamento de erros na view de processamento.